### PR TITLE
End game: update game logic

### DIFF
--- a/components/pages/game/components/Game.tsx
+++ b/components/pages/game/components/Game.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { RESULT } from 'config/routes';
 import DefaultTemplate from 'components/shared/templates/DefaultTemplate';
 import TimerBar from 'components/shared/atoms/TimerBar';
-// import useEndGame from 'lib/apollo/hooks/actions/endGame';
+import useEndGame from 'lib/apollo/hooks/actions/useEndGame';
 import useSendAnswerAndGetNextQuestion from 'lib/apollo/hooks/actions/sendAnswerAndGetNextQuestion';
 import { useRouter } from 'next/router';
 import GameStep from './GameStep';
@@ -40,9 +40,13 @@ const Game = ({ initialQuestion, gameId }: { initialQuestion: Question; gameId: 
   const [currentAnswer, setCurrentAnswer] = useState<string | undefined>(undefined);
 
   const [sendAnswerAndGetNextQuestion, { data, loading, error }] = useSendAnswerAndGetNextQuestion();
-  // const [endGame] = useEndGame();
+  const [endGame, endGameState] = useEndGame();
 
   const router = useRouter();
+
+  useEffect(() => {
+    if (endGameState.data?.endGame) router.push(RESULT);
+  }, [endGameState.data?.endGame, router]);
 
   const isCurrentAnswerCorrect =
     !loading && !error && data?.sendAnswerAndGetNextQuestion.question !== currentQuestion
@@ -76,8 +80,7 @@ const Game = ({ initialQuestion, gameId }: { initialQuestion: Question; gameId: 
   };
 
   const endGameHandler = () => {
-    // endGame(gameId);
-    router.push(RESULT);
+    endGame({ gameId });
   };
 
   const currentSecond = useTimer(FULL_TIME, endGameHandler);
@@ -89,7 +92,7 @@ const Game = ({ initialQuestion, gameId }: { initialQuestion: Question; gameId: 
       title="What is the name of that superhero?"
       headerChildren={
         <HeaderChildren
-          // endGame={endGameHandler}
+          endGame={endGameHandler}
           correctAnswersCount={data?.sendAnswerAndGetNextQuestion.correctAnswersCount}
         />
       }

--- a/components/pages/game/components/HeaderChildren.tsx
+++ b/components/pages/game/components/HeaderChildren.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import styled, { css } from 'styled-components';
 
 import { component as Exit } from 'public/images/icons/exit.svg';
@@ -38,16 +38,21 @@ const ExitIcon = styled(Exit)(
 
 const HeaderChildren = ({
   correctAnswersCount,
-}: // endGame,
-{
+  endGame,
+}: {
   correctAnswersCount: number | undefined;
-  // endGame: (gameId: string) => void;
+  endGame: () => void;
 }) => {
+  const refCount = useRef(0);
+  if (correctAnswersCount) {
+    refCount.current = correctAnswersCount;
+  }
+
   return (
     <Wrapper>
-      <CountAnswer>{correctAnswersCount}</CountAnswer>
+      <CountAnswer>{correctAnswersCount || refCount.current}</CountAnswer>
       <StarIcon src={`${process.env.ASSET_HOST}/images/icons/star.png`} />
-      <ExitIcon onClick={() => {}} />
+      <ExitIcon onClick={endGame} />
     </Wrapper>
   );
 };

--- a/graphql/mutations/endGame.graphql
+++ b/graphql/mutations/endGame.graphql
@@ -1,0 +1,5 @@
+mutation endGame($input: EndGameInput!) {
+  endGame(input: $input) {
+    score
+  }
+}

--- a/lib/apollo/hooks/actions/useEndGame.test.js
+++ b/lib/apollo/hooks/actions/useEndGame.test.js
@@ -1,0 +1,52 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { MockedProvider } from '@apollo/client/testing';
+
+import EndGame from 'graphql/mutations/endGame.graphql';
+
+import { useNotifier } from 'contexts/NotifierContext';
+
+import useEndGame from './useEndGame';
+
+jest.mock('contexts/NotifierContext');
+
+describe('useEndGame', () => {
+  useNotifier.mockImplementation(jest.fn(() => ({ setError: jest.fn(), setSuccess: jest.fn() })));
+
+  test('should mutate state', async () => {
+    // Arrange
+    const responseMock = { score: 1, __typename: 'Result' };
+    const gameId = '1';
+    const endGameInput = {
+      gameId,
+    };
+
+    const mocks = [
+      {
+        request: {
+          query: EndGame,
+          variables: { input: endGameInput },
+        },
+        result: {
+          data: {
+            endGame: responseMock,
+          },
+        },
+      },
+    ];
+
+    // Act
+    const { result, waitForNextUpdate } = renderHook(() => useEndGame(), {
+      wrapper: MockedProvider,
+      initialProps: {
+        mocks,
+      },
+    });
+    act(() => {
+      result.current[0](endGameInput);
+    });
+    await waitForNextUpdate();
+
+    // Assert
+    expect(result.current[1].data.endGame).toEqual(responseMock);
+  });
+});

--- a/lib/apollo/hooks/actions/useEndGame.ts
+++ b/lib/apollo/hooks/actions/useEndGame.ts
@@ -1,0 +1,43 @@
+import { useMutation } from '@apollo/client';
+
+import { useNotifier } from 'contexts/NotifierContext';
+import { useCallback } from 'react';
+
+import EndGame from 'graphql/mutations/endGame.graphql';
+
+type EndGameProps = { gameId: string };
+
+type EndGameData = {
+  endGame: {
+    score: number;
+  };
+};
+
+type EndGameInputVariable = EndGameProps;
+
+type EndGameVariables = {
+  input: EndGameInputVariable;
+};
+
+const useEndGame = () => {
+  const { setError } = useNotifier();
+
+  const [mutation, endGameState] = useMutation<EndGameData, EndGameVariables>(EndGame, {
+    onError: (error) => {
+      if (setError) setError(error);
+    },
+  });
+
+  const endGame = useCallback(
+    (gameId: EndGameProps) => {
+      return mutation({
+        variables: { input: gameId },
+      });
+    },
+    [mutation],
+  );
+
+  return [endGame, endGameState] as const;
+};
+
+export default useEndGame;


### PR DESCRIPTION
# Summary

#### A brief description of the pull request.
- added `useEndGame` hook, test
- update game logic using new mutation `EndGame`
- show prev value of score in game header if user is waiting for a result after answering (no counter blinking) 

[[FE] - переделать логику работы с мутацией endGame](https://app.clickup.com/t/1t7hzdf)
[[FE] - сделать так, чтобы не мигал счетчик правильных ответов](https://app.clickup.com/t/1vc0azc)

#### Screenshots in case of UI changes

https://user-images.githubusercontent.com/88319167/143871639-cdddcc75-09f8-4672-96c7-3d7b368fd1db.mov

https://user-images.githubusercontent.com/88319167/143871677-8a3f44ae-b636-4c29-8f50-e47ce9ddab6f.mov


# Test plan

# Review notes

#### While reviewing pull-request (especially when it's your pull-request), please make sure that:

- you named PR close to issue name and linked that issue
- you understand what problem is solved by PR and how is it solved
- new tests are in place, no redundant tests
- required ENV variables added and described in `.env.example` and added to Heroku
- associated Heroku review app works correctly with introduced changes
